### PR TITLE
Improve Join Condition Parsing for Complex Queries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container: node:20
-    # env:
-    #   COMPOSE_FILE: ./docker-compose.yml
+    env:
+      COMPOSE_FILE: ./docker-compose.yml
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -356,6 +356,7 @@ qb.select(['foo', 'bar'])
     on: [
       { field: 'bar', operator: 'eq', value: 100 },
       { field: 'baz', operator: 'isnull' },
+      { field: 'date', operator: 'between', value: ['2023-01-01', '2023-12-31'] },
     ],
   })
   .sortBy({ field: 'bar', order: 'DESС' })

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -222,7 +222,7 @@ _Examples:_
 
 The join parameter now supports specifying a WHERE condition within the ON clause of the join using the on property. This allows for more granular control over the joined data.
 
-> ?join[]=**relation**||**field1**,**field2**,...||on[0]=**field**||**\$condition**||**value**,on[1]=**field**||**\$condition**...&join[]=...
+> ?join[]=**relation**||**field1**,**field2**,...||on[0]=**field**||**\$condition**||**value**&on[1]=**field**||**\$condition**...&join[]=...
 
 _Examples:_
 

--- a/packages/crud-request/src/request-query.builder.ts
+++ b/packages/crud-request/src/request-query.builder.ts
@@ -60,7 +60,7 @@ export class RequestQueryBuilder {
   } = {};
   private joinConditionString: IStringifyOptions = {
     encode: false,
-    delimiter: this.options.delimStr,
+    delimiter: '&',
     arrayFormat: 'indices',
   };
   public queryObject: { [key: string]: any } = {};

--- a/packages/crud-request/src/request-query.parser.ts
+++ b/packages/crud-request/src/request-query.parser.ts
@@ -356,14 +356,14 @@ export class RequestQueryParser implements ParsedRequestParams {
   }
 
   private parseJoinConditions(conditionsString: string): QueryFilter[] {
-    const conditions: string[] = parse(conditionsString, this._joinConditionParseOptions)[
-      'on'
-    ];
+    const conditions: string[] = parse(conditionsString)['on'];
+
     return conditions.map((cond: string) => this.conditionParser('filter', {}, cond));
   }
 
   private joinParser(data: string): QueryJoin {
     const param = data.split(this._options.delim);
+
     const field = param[0];
     const selectString = param[1];
     const conditions = param.slice(2).join(this._options.delim);

--- a/packages/crud-request/test/request-query.builder.spec.ts
+++ b/packages/crud-request/test/request-query.builder.spec.ts
@@ -223,7 +223,24 @@ describe('#request-query', () => {
             ],
           },
         ]);
-        const expected = ['baz||a,b,c||on[0]=bar||eq||100,on[1]=foo||isnull'];
+        const expected = ['baz||a,b,c||on[0]=bar||eq||100&on[1]=foo||isnull'];
+        expect(qb.queryObject.join).toIncludeSameMembers(expected);
+      });
+      it('should set join, 9', () => {
+        qb.setJoin([
+          {
+            field: 'qux',
+            select: ['a', 'b', 'c'],
+            on: [
+              { field: 'bar', operator: 'eq', value: 100 },
+              { field: 'foo', operator: 'isnull' },
+              { field: 'date', operator: 'between', value: ['2023-12-06', '2023-12-12'] },
+            ],
+          },
+        ]);
+        const expected = [
+          'qux||a,b,c||on[0]=bar||eq||100&on[1]=foo||isnull&on[2]=date||between||2023-12-06,2023-12-12',
+        ];
         expect(qb.queryObject.join).toIncludeSameMembers(expected);
       });
     });
@@ -384,6 +401,7 @@ describe('#request-query', () => {
             on: [
               { field: 'foo', operator: 'eq', value: 'baz' },
               { field: 'bar', operator: 'isnull' },
+              { field: 'qux', operator: 'between', value: [1000, 8000] },
             ],
           })
           .setLimit(1)
@@ -394,7 +412,7 @@ describe('#request-query', () => {
           .setIncludeDeleted(1)
           .query(false);
         const expected =
-          'fields=foo,bar&filter[0]=is||notnull&or[0]=ok||ne||false&join[0]=voo||h,data||on[0]=foo||eq||baz,on[1]=bar||isnull&limit=1&offset=2&page=3&sort[0]=foo,DESC&cache=0&include_deleted=1';
+          'fields=foo,bar&filter[0]=is||notnull&or[0]=ok||ne||false&join[0]=voo||h,data||on[0]=foo||eq||baz&on[1]=bar||isnull&on[2]=qux||between||1000,8000&limit=1&offset=2&page=3&sort[0]=foo,DESC&cache=0&include_deleted=1';
         expect(test).toBe(expected);
       });
     });
@@ -437,6 +455,7 @@ describe('#request-query', () => {
             on: [
               { field: 'foo', operator: 'eq', value: 'baz' },
               { field: 'bar', operator: 'isnull' },
+              { field: 'qux', operator: 'between', value: [1000, 8000] },
             ],
           },
           limit: 1,
@@ -446,7 +465,7 @@ describe('#request-query', () => {
           resetCache: true,
         }).query(false);
         const expected =
-          'fields=foo,bar&filter[0]=is||notnull&or[0]=ok||ne||false&join[0]=voo||h,data||on[0]=foo||eq||baz,on[1]=bar||isnull&limit=1&offset=2&page=3&sort[0]=foo,DESC&cache=0';
+          'fields=foo,bar&filter[0]=is||notnull&or[0]=ok||ne||false&join[0]=voo||h,data||on[0]=foo||eq||baz&on[1]=bar||isnull&on[2]=qux||between||1000,8000&limit=1&offset=2&page=3&sort[0]=foo,DESC&cache=0';
         expect(test).toBe(expected);
       });
       it('should return a valid query string, 2', () => {

--- a/packages/crud-request/test/request-query.parser.spec.ts
+++ b/packages/crud-request/test/request-query.parser.spec.ts
@@ -264,7 +264,7 @@ describe('#request-query', () => {
             join: [
               'foo',
               'bar||baz,boo',
-              'bar||baz,boo||on[0]=name||eq||jhon,on[1]=foo||isnull',
+              'bar||baz,boo||on[0]=name||eq||jhon&on[1]=foo||isnull',
             ],
           };
           const expected: QueryJoin[] = [
@@ -284,6 +284,45 @@ describe('#request-query', () => {
           expect(test.join[0]).toMatchObject(expected[0]);
           expect(test.join[1]).toMatchObject(expected[1]);
           expect(test.join[2]).toMatchObject(expected[2]);
+        });
+        it('should set array, 4', () => {
+          const query = {
+            join: [
+              'foo',
+              'bar||baz,boo',
+              'bar||baz,boo||on[0]=name||eq||jhon&on[1]=foo||isnull',
+              'qux||qubaz,quboo||on[0]=quux||between||06-12-2023,12-12-2023',
+            ],
+          };
+          const expected: QueryJoin[] = [
+            { field: 'foo' },
+            { field: 'bar', select: ['baz', 'boo'] },
+            {
+              field: 'bar',
+              select: ['baz', 'boo'],
+              on: [
+                { field: 'name', operator: 'eq', value: 'jhon' },
+                { field: 'foo', operator: 'isnull', value: '' },
+              ],
+            },
+            {
+              field: 'qux',
+              select: ['qubaz', 'quboo'],
+              on: [
+                {
+                  field: 'quux',
+                  operator: 'between',
+                  value: ['06-12-2023', '12-12-2023'],
+                },
+              ],
+            },
+          ];
+          const test = qp.parseQuery(query);
+
+          expect(test.join[0]).toMatchObject(expected[0]);
+          expect(test.join[1]).toMatchObject(expected[1]);
+          expect(test.join[2]).toMatchObject(expected[2]);
+          expect(test.join[3]).toMatchObject(expected[3]);
         });
       });
 


### PR DESCRIPTION
### Description
Enhance the join condition parsing mechanism to support more complex query scenarios, particularly those involving array-like values such as date ranges.

### Key Changes
- Modified join condition parsing to use '&' as a delimiter
- Implemented robust handling of array values in join conditions
- Updated documentation to reflect new parsing approach
- Added comprehensive test coverage

### Detailed Improvements

1. Parsing Mechanism
    - Replaced existing query string parsing approach
    - Introduced '&' symbol as a new delimiter for join conditions
    - Improved support for array values in on clauses

2. Testing
    - Added new test cases covering join conditions with array values
    - Verified parsing of complex query strings, including date range examples

3. Documentation
    - Updated documentation to explain new join condition syntax
    - Provided clear examples of using join conditions with array values

### Example Usage
```
# New syntax for join conditions with array values
join[]=events||id,name||on[0]=event.status||$eq||active&on[1]=event.date||$between||16-12-2023,23-12-2023
```

### Impact
- Increased flexibility in constructing complex join conditions
- Better support for range-based and multi-value filters
- More intuitive query string parsing

### Related Issues
Closes #68 (if applicable)

### Type of Changes
- Bug Fix
- Query String Parsing Improvement
- Documentation Update

### Testing
- Comprehensive test suite added
- Verified parsing of various join condition scenarios


